### PR TITLE
[common] conditional ServiceEntry creation

### DIFF
--- a/charts/adminer/values.yaml
+++ b/charts/adminer/values.yaml
@@ -541,6 +541,7 @@ gateway:
     #   protocol: HTTPS
   existingGateway: ~
   existingVirtualService: ~
+  existingServiceEntry: ~
   ## @param gateway.extraRoute Array of extra Kubernetes Gateway API Route to deploy with the release
   ##
   extraRoute: []

--- a/charts/freeradius/values.yaml
+++ b/charts/freeradius/values.yaml
@@ -538,7 +538,7 @@ service:
   ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  ## @param service.allocateLoadBalancerNodePorts Allow users to disable node ports for Service Type=LoadBalancer. This is useful for 
+  ## @param service.allocateLoadBalancerNodePorts Allow users to disable node ports for Service Type=LoadBalancer. This is useful for
   ## bare metal / on-prem environments that rely on VIP based LB implementations.
   allocateLoadBalancerNodePorts: false
   ## @param service.loadBalancerClass Enables to use a load balancer implementation other than the cloud provider default.
@@ -896,6 +896,7 @@ gateway:
   listeners: []
   existingGateway: ~
   existingVirtualService: ~
+  existingServiceEntry: ~
   ## @param gateway.extraRoute Array of extra Kubernetes Gateway API Route to deploy with the release
   ##
   extraRoute: []
@@ -907,7 +908,7 @@ metrics:
   ##
   enabled: false
   ## Bitnami FreeRADIUS Prometheus exporter image
-  ## ref: 
+  ## ref:
   ## @param metrics.image.registry FreeRADIUS Prometheus exporter image registry
   ## @param metrics.image.repository FreeRADIUS Prometheus exporter image repository
   ## @param metrics.image.tag FreeRADIUS Prometheus exporter image tag (immutable tags are recommended)
@@ -916,8 +917,8 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: 
-    tag: 
+    repository:
+    tag:
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/charts/netbox/templates/istio/ServiceEntry.yaml
+++ b/charts/netbox/templates/istio/ServiceEntry.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.gateway.enabled (not .Values.gateway.existingServiceEntry) (not .Values.gateway.gatewayApi.create) -}}
 {{- if (include "common.capabilities.istioNetworking.apiVersion" .) -}}
 apiVersion: {{ include "common.capabilities.istioNetworking.apiVersion" . }}
 kind: ServiceEntry
@@ -16,4 +17,5 @@ spec:
       name: https
       protocol: TLS
   resolution: DNS
+{{- end -}}
 {{- end -}}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1138,7 +1138,7 @@ service:
   clusterIP: ""
   clusterIPs: []
   externalIPs: []
-  ## @param service.allocateLoadBalancerNodePorts Allow users to disable node ports for Service Type=LoadBalancer. This is useful for 
+  ## @param service.allocateLoadBalancerNodePorts Allow users to disable node ports for Service Type=LoadBalancer. This is useful for
   ## bare metal / on-prem environments that rely on VIP based LB implementations.
   ## ref https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
   ##
@@ -2420,23 +2420,23 @@ gateway:
   ## @param gateway.enabled  Enable Istio Gateway and VirtualService
   ##
   enabled: false
-  ## @param gateway.dedicated 
-  ## 
+  ## @param gateway.dedicated
+  ##
   dedicated: false
-  ## @param gateway.gatewayApi 
-  ## 
+  ## @param gateway.gatewayApi
+  ##
   gatewayApi:
     ## @param gateway.gatewayApi.create  Create Kubernetes Gateway API gateway
-    ## 
+    ##
     create: false
-  ## @param gateway.name 
-  ## 
+  ## @param gateway.name
+  ##
   name: ""
-  ## @param gateway.namespace 
-  ## 
+  ## @param gateway.namespace
+  ##
   namespace: ""
-  ## @param gateway.gatewayClassName 
-  ## 
+  ## @param gateway.gatewayClassName
+  ##
   gatewayClassName: istio
   ## @param gateway.listeners
   ##
@@ -2453,8 +2453,12 @@ gateway:
   ## @param gateway.existingVirtualService
   ##
   existingVirtualService: ~
+  ## @param gateway.existingServiceEntry
+  ##
+  existingServiceEntry: ~
   ## @param gateway.extraRoute Array of extra Kubernetes Gateway API Route to deploy with the release
   ##
+
   extraRoute: []
 
 organization: Startechnica


### PR DESCRIPTION
In case there is no gateway API support in the cluster, ServiceEntry still gets templated with an apiVersion set to `false`, which causes an error such as `error validating "": error validating data: apiVersion isn't string type`. I can remove the white space formatting if this is an issue.