### PR TITLE
[netbox] make istio ServiceEntry creation conditional

### DIFF
--- a/charts/netbox/templates/istio/ServiceEntry.yaml
+++ b/charts/netbox/templates/istio/ServiceEntry.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.gateway.enabled (not .Values.gateway.existingServiceEntry) (not .Values.gateway.gatewayApi.create) -}}
 {{- if (include "common.capabilities.istioNetworking.apiVersion" .) -}}
 apiVersion: {{ include "common.capabilities.istioNetworking.apiVersion" . }}
 kind: ServiceEntry
@@ -16,4 +17,5 @@ spec:
       name: https
       protocol: TLS
   resolution: DNS
+{{- end -}}
 {{- end -}}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -2453,6 +2453,9 @@ gateway:
   ## @param gateway.existingVirtualService
   ##
   existingVirtualService: ~
+  ## @param gateway.existingServiceEntry
+  ##
+  existingServiceEntry: ~  
   ## @param gateway.extraRoute Array of extra Kubernetes Gateway API Route to deploy with the release
   ##
   extraRoute: []


### PR DESCRIPTION
In case there is no gateway API support in the cluster, ServiceEntry still gets templated with an apiVersion set to false, which causes an error such as `error validating "": error validating data: apiVersion isn't string type`.
