### PR TITLE
Add missing import if allowedHostsIncludesPodIp is true

### DIFF
--- a/charts/netbox/templates/ConfigMap/netbox.yaml
+++ b/charts/netbox/templates/ConfigMap/netbox.yaml
@@ -8,6 +8,9 @@ metadata:
   labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
 data:
   configuration.py: |-
+    {{- if .Values.allowedHostsIncludesPodIp }}
+    import os
+    {{- end }}
     import re
     from pathlib import Path
 


### PR DESCRIPTION
Fixes the `NameError: name 'os' is not defined` error on startup if `allowedHostsIncludesPodIp` is set to `true`.