### PR TITLE
charts/freeradius: fixes and improvements

### DIFF
--- a/charts/freeradius/Chart.yaml
+++ b/charts/freeradius/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://freeradius.org/
   - https://github.com/FreeRADIUS/freeradius-server
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/charts/freeradius/Chart.yaml
+++ b/charts/freeradius/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 3.2.7
 dependencies:
   - name: st-common
     repository: https://startechnica.github.io/apps
-    version: 0.1.10
+    version: 0.1.12
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/freeradius/templates/Certificate.yaml
+++ b/charts/freeradius/templates/Certificate.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "freeradius.createTlsSecret" .) .Values.tls.autoGenerator.certmanager.enabled }}
-{{- if not (eq (include "st-common.capabilities.certManager.apiVersion" .) "false") }}
+{{- if not (eq (include "st-common.capabilities.certmanager.apiVersion" .) "false") }}
 {{- $releaseNamespace := include "st-common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $fullname := include "st-common.names.fullname" . }}
@@ -13,25 +13,26 @@ SPDX-License-Identifier: APACHE-2.0
 {{/*
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc" $serviceName $releaseNamespace) (printf "%s.%s" $serviceName $releaseNamespace) $fullname }}
 */}}
-apiVersion: {{ include "st-common.capabilities.certManager.apiVersion" . }}
+apiVersion: {{ include "st-common.capabilities.certmanager.apiVersion" . }}
 kind: Certificate
 metadata:
   name: {{ include "st-common.names.fullname" . }}-tls
   namespace: {{ include "st-common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
-  {{- end }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   secretName: {{ include "freeradius.tlsSecretName" . }}
   issuerRef:
     group: cert-manager.io
     kind: {{ .Values.tls.autoGenerator.certmanager.issuerKind }}
     name: {{ .Values.tls.autoGenerator.certmanager.issuerName }}
-    #name: letsencrypt-prd
   privateKey:
     algorithm: ECDSA
     rotationPolicy: Always

--- a/charts/freeradius/templates/Certificate.yaml
+++ b/charts/freeradius/templates/Certificate.yaml
@@ -5,14 +5,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- if and (include "freeradius.createTlsSecret" .) .Values.tls.autoGenerator.certmanager.enabled }}
 {{- if not (eq (include "st-common.capabilities.certmanager.apiVersion" .) "false") }}
-{{- $releaseNamespace := include "st-common.names.namespace" . }}
-{{- $clusterDomain := .Values.clusterDomain }}
-{{- $fullname := include "st-common.names.fullname" . }}
-{{- $serviceName := include "st-common.names.fullname" . }}
-{{- $altNames := list (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc" $serviceName $releaseNamespace) (printf "%s.%s" $serviceName $releaseNamespace) $fullname }}
-{{/*
-{{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc" $serviceName $releaseNamespace) (printf "%s.%s" $serviceName $releaseNamespace) $fullname }}
-*/}}
 apiVersion: {{ include "st-common.capabilities.certmanager.apiVersion" . }}
 kind: Certificate
 metadata:
@@ -33,23 +25,18 @@ spec:
     group: cert-manager.io
     kind: {{ .Values.tls.autoGenerator.certmanager.issuerKind }}
     name: {{ .Values.tls.autoGenerator.certmanager.issuerName }}
+  {{- if .Values.tls.autoGenerator.certmanager.privateKey }}
   privateKey:
-    algorithm: ECDSA
-    rotationPolicy: Always
-    size: 256
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.tls.autoGenerator.certmanager.privateKey "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tls.autoGenerator.certmanager.subject }}
   subject:
-    organizations:
-      - {{ .Release.Name | quote }}
-    organizationalUnits:
-      - {{ include "st-common.names.fullname" . }}
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.tls.autoGenerator.certmanager.subject "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tls.autoGenerator.certmanager.dnsNames }}
   dnsNames:
-    - {{ .Values.ingress.hostname | quote }}
-    {{- range .Values.ingress.extraHosts }}
-    - {{ .name | quote }}
-    {{- end }}
-    {{- with $altNames }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.tls.autoGenerator.certmanager.dnsNames "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/freeradius/templates/ConfigMap/clients.yaml
+++ b/charts/freeradius/templates/ConfigMap/clients.yaml
@@ -10,12 +10,14 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-clients" (include "st-common.names.fullname" .) }}
   namespace: {{ include "st-common.names.namespace" . | quote }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 data:
   clients.conf: |-

--- a/charts/freeradius/templates/ConfigMap/configuration.yaml
+++ b/charts/freeradius/templates/ConfigMap/configuration.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright (c) 2025 Firmansyah Nainggolan. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.configuration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "freeradius.configurationCM" . }}
+  namespace: {{ include "st-common.names.namespace" . | quote }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+data:
+  radiusd.conf: |-
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.configuration "context" $) | nindent 4 }}
+{{- end }}

--- a/charts/freeradius/templates/ConfigMap/envvars.yaml
+++ b/charts/freeradius/templates/ConfigMap/envvars.yaml
@@ -8,12 +8,14 @@ kind: ConfigMap
 metadata:
   name: {{ include "freeradius.names.envvars" . }}
   namespace: {{ include "st-common.names.namespace" . | quote }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 data:
   FREERADIUS_ENABLE_TLS: {{ ternary "true" "false" .Values.tls.enabled | quote }}

--- a/charts/freeradius/templates/ConfigMap/mods-enabled.yaml
+++ b/charts/freeradius/templates/ConfigMap/mods-enabled.yaml
@@ -8,12 +8,14 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-mods" (include "st-common.names.fullname" .) }}
   namespace: {{ include "st-common.names.namespace" . | quote }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 data:
 {{- if .Values.modsEnabled.sql.enabled }}

--- a/charts/freeradius/templates/Deployment.yaml
+++ b/charts/freeradius/templates/Deployment.yaml
@@ -38,6 +38,7 @@ spec:
         checksum/secret-credentials: {{ include (print $.Template.BasePath "/Secret/credentials.yaml") . | sha256sum }}
         checksum/secret-sql-tls: {{ include (print $.Template.BasePath "/Secret/sql-tls.yaml") . | sha256sum }}
         checksum/secret-tls: {{ include (print $.Template.BasePath "/Secret/tls.yaml") . | sha256sum }}
+        checksum/secret-env: {{ include (print $.Template.BasePath "/Secret/envvars.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
           {{- include "st-common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -173,13 +174,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "freeradius.names.envvars" . }}
-            {{- if .Values.extraEnvVarsCM }}
-            - configMapRef:
-                name: {{ .Values.extraEnvVarsCM }}
-            {{- end }}
-            {{- if .Values.extraEnvVarsSecret }}
+            {{- if .Values.extraSecretEnvVars }}
             - secretRef:
-                name: {{ .Values.extraEnvVarsSecret }}
+                name: {{ include "freeradius.names.envvars" . }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsExistingCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsExistingCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsExistingSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsExistingSecret }}
             {{- end }}
           {{- if .Values.lifecycleHooks }}
           lifecycle: {{- include "st-common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}

--- a/charts/freeradius/templates/Deployment.yaml
+++ b/charts/freeradius/templates/Deployment.yaml
@@ -34,6 +34,7 @@ spec:
         checksum/configmap-env: {{ include (print $.Template.BasePath "/ConfigMap/envvars.yaml") . | sha256sum }}
         checksum/configmap-mods: {{ include (print $.Template.BasePath "/ConfigMap/mods-enabled.yaml") . | sha256sum }}
         checksum/configmap-sites: {{ include (print $.Template.BasePath "/ConfigMap/sites-enabled.yaml") . | sha256sum }}
+        checksum/configmap-configuration: {{ include (print $.Template.BasePath "/ConfigMap/configuration.yaml") . | sha256sum }}
         checksum/secret-credentials: {{ include (print $.Template.BasePath "/Secret/credentials.yaml") . | sha256sum }}
         checksum/secret-sql-tls: {{ include (print $.Template.BasePath "/Secret/sql-tls.yaml") . | sha256sum }}
         checksum/secret-tls: {{ include (print $.Template.BasePath "/Secret/tls.yaml") . | sha256sum }}

--- a/charts/freeradius/templates/Deployment.yaml
+++ b/charts/freeradius/templates/Deployment.yaml
@@ -246,6 +246,7 @@ spec:
                   /bin/echo "Message-Authenticator = 0x00" | /usr/bin/radclient 127.0.0.1:${FREERADIUS_SITES_STATUS_PORT} status ${FREERADIUS_SITES_STATUS_SECRET}
           {{- end }}
           {{- end }}
+          {{- end }}
           {{- if .resources }}
           resources: {{- include "st-common.tplvalues.render" (dict "value" .resources "context" $) | nindent 12 }}
           {{- else if and .resourcesPreset (ne .resourcesPreset "none") }}

--- a/charts/freeradius/templates/Secret/credentials.yaml
+++ b/charts/freeradius/templates/Secret/credentials.yaml
@@ -10,13 +10,15 @@ kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ include "st-common.names.namespace" . | quote }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
     app.kubernetes.io/component: freeradius
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/freeradius/templates/Secret/envvars.yaml
+++ b/charts/freeradius/templates/Secret/envvars.yaml
@@ -3,10 +3,11 @@ Copyright (c) 2025 Firmansyah Nainggolan. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.extraSecretEnvVars }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ printf "%s-sites" (include "st-common.names.fullname" .) }}
+  name: {{ include "freeradius.names.envvars" . }}
   namespace: {{ include "st-common.names.namespace" . | quote }}
   labels:
     {{- include "st-common.labels.standard" . | nindent 4 }}
@@ -17,15 +18,7 @@ metadata:
   annotations:
     {{- include "st-common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
-data:
-{{ (.Files.Glob "files/sites-available/default").AsConfig | indent 2 }}
-{{ (.Files.Glob "files/sites-available/inner-tunnel").AsConfig | indent 2 }}
-{{- if .Values.sitesEnabled.coa.enabled }}
-{{ (.Files.Glob "files/sites-available/coa").AsConfig | indent 2 }}
-{{- end }}
-{{- if .Values.sitesEnabled.status.enabled }}
-{{ (.Files.Glob "files/sites-available/status").AsConfig | indent 2 }}
-{{- end }}
-{{- if .Values.sitesEnabled.tls.enabled }}
-{{ (.Files.Glob "files/sites-available/tls").AsConfig | indent 2 }}
+type: Opaque
+stringData:
+  {{- include "st-common.tplvalues.render" (dict "value" .Values.extraSecretEnvVars "context" $) | nindent 4 }}
 {{- end }}

--- a/charts/freeradius/templates/Secret/sql-tls.yaml
+++ b/charts/freeradius/templates/Secret/sql-tls.yaml
@@ -16,9 +16,11 @@ metadata:
   name: {{ include "st-common.names.fullname" . }}-sql-tls
   namespace: {{ include "st-common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/freeradius/templates/Secret/tls.yaml
+++ b/charts/freeradius/templates/Secret/tls.yaml
@@ -16,9 +16,11 @@ metadata:
   name: {{ include "st-common.names.fullname" . }}-tls
   namespace: {{ include "st-common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations:
+    {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  labels: {{- include "st-common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "st-common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
       {{- include "st-common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/freeradius/values.yaml
+++ b/charts/freeradius/values.yaml
@@ -906,6 +906,27 @@ tls:
       enabled: false
       issuerKind: ClusterIssuer
       issuerName: selfsigned-issuer
+      privateKey:
+        algorithm: ECDSA
+        rotationPolicy: Always
+        size: 256
+      subject: |-
+        organizations:
+          - {{ .Release.Name | quote }}
+        organizationalUnits:
+          - {{ include "st-common.names.fullname" . | quote }}
+      dnsNames: |-
+        {{- $releaseNamespace := include "st-common.names.namespace" . }}
+        {{- $clusterDomain := .Values.clusterDomain }}
+        {{- $serviceName := include "st-common.names.fullname" . }}
+        {{- $altNames := list (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc" $serviceName $releaseNamespace) (printf "%s.%s" $serviceName $releaseNamespace) $serviceName -}}
+        - {{ .Values.ingress.hostname | quote }}
+        {{- range .Values.ingress.extraHosts }}
+        - {{ .name | quote }}
+        {{- end }}
+        {{- with $altNames }}
+        {{ toYaml . }}
+        {{- end }}
   ## @param tls.certificatesSecret Name of the secret that contains the certificates
   ##
   certificatesSecret: ""

--- a/charts/freeradius/values.yaml
+++ b/charts/freeradius/values.yaml
@@ -391,16 +391,23 @@ extraFlags: ""
 ## @param extraEnvVars Extra environment variables to be set on FreeRADIUS containers
 ## E.g.
 ## extraEnvVars:
-##  - name: TZ
-##    value: "Europe/Paris"
+##   - name: TZ
+##     value: "Europe/Paris"
 ##
 extraEnvVars: []
-## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for FreeRADIUS containers
+
+## @param extraSecretEnvVars Extra environment variables to be stored in Secret and set on FreeRADIUS containers
+## E.g.
+## extraSecretEnvVars:
+##   FREERADIUS_PROXY_SECRET: test123456
+extraSecretEnvVars: {}
+
+## @param extraEnvVarsExistingCM Name of existing ConfigMap containing extra env vars for FreeRADIUS containers
 ##
-extraEnvVarsCM: ""
-## @param extraEnvVarsSecret Name of existing Secret containing extra env vars for FreeRADIUS containers
+extraEnvVarsExistingCM: ""
+## @param extraEnvVarsExistingSecret Name of existing Secret containing extra env vars for FreeRADIUS containers
 ##
-extraEnvVarsSecret: ""
+extraEnvVarsExistingSecret: ""
 
 ## @section Persistence Parameters
 


### PR DESCRIPTION
fixes #96 and fixes #97

- fixes typos, missing templates and formatting
- allows better cert-manager certificate configuration while keeping compatibility with previous default settings - allows to use ACME / Let's Encrypt for generating FreeRADIUS TLS certificates
- adds possibility to define env vars kept in secret from within values
- adds configuration overwrite configmap (was documented in values but not implemented)
- renames `.Values.extraEnvVarsCM` to `.Values.extraEnvVarsExistingCM` and `.Values.extraEnvVarsSecret` to `.Values.extraEnvVarsExistingSecret`