### PR TITLE
Bug fix of readiness probe

### DIFF
--- a/charts/freeradius/Chart.yaml
+++ b/charts/freeradius/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://freeradius.org/
   - https://github.com/FreeRADIUS/freeradius-server
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/charts/freeradius/templates/Deployment.yaml
+++ b/charts/freeradius/templates/Deployment.yaml
@@ -236,7 +236,7 @@ spec:
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "st-common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
-          {{- if .Values.readinessProbe.enabled }}
+          {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
             exec:
               command:


### PR DESCRIPTION
Fixed the readiness probe in the deployment template which caused the chart to be broken since there was a mismatch of if and end statements. 