### PR TITLE
[adminer] Bump version to 1.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -22,15 +25,27 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5.0.0
         with:
           version: latest
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        id: cr
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
-          HELM_EXPERIMENTAL_OCI: 1
+
+      - name: Login to GHCR
+        if: steps.cr.outputs.changed_charts != ''
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push charts to GHCR (OCI)
+        if: steps.cr.outputs.changed_charts != ''
+        run: |
+          shopt -s nullglob
+          for tgz in .cr-release-packages/*.tgz; do
+            helm push "$tgz" oci://ghcr.io/${{ github.repository_owner }}/charts
+          done

--- a/charts/adminer/CHANGELOG.md
+++ b/charts/adminer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.1 (2026-05-02)
+
+Documentation and validation polish on top of 1.0.0. No template or values
+default changes — installs from 1.0.0 upgrade in place with no action.
+
+### Added
+
+- `values.schema.json` — JSON Schema generated from `values.yaml` defaults. Permissive (no `required`, no `additionalProperties: false`); catches gross type mistakes (`replicaCount: "two"`, `service.type: 8080`) at `helm install`/`upgrade` time. Null defaults map to `{}` (any), so existing overrides continue to validate.
+- `README.md`: Artifact Hub repository badge plus static `Version` / `Type` / `AppVersion` shields under the title.
+
+### Fixed
+
+- `values.yaml`: duplicate `metrics.serviceMonitor.endpoints` key under `metrics.serviceMonitor`. Helm's YAML loader silently kept the last value (`endpoints: []`) and discarded the shorthand `endpoints: [{path: /metrics}]` that the section above intended. Behavior of the rendered ServiceMonitor is unchanged because `templates/ServiceMonitor.yaml` already falls back to the synthetic single-endpoint when `endpoints` is empty — but stricter YAML loaders (yaml.v3, js-yaml, kubeval pipelines) rejected the file outright.
+
 ## 1.0.0 (2026-05-02)
 
 Major release. Substantial restructuring of TLS / cert-manager values, plus a

--- a/charts/adminer/Chart.yaml
+++ b/charts/adminer/Chart.yaml
@@ -4,8 +4,12 @@ annotations:
     - name: adminer
       image: docker.io/adminer:5.4.2-standalone
   artifacthub.io/changes: |
-    - kind: changed
-      description: "1.0.0 major release — TLS/cert-manager value keys consolidated; see CHANGELOG.md and README §Upgrading for migration."
+    - kind: added
+      description: "values.schema.json for runtime validation of values overrides."
+    - kind: added
+      description: "Artifact Hub / Version / Type / AppVersion shields in README."
+    - kind: fixed
+      description: "Duplicate metrics.serviceMonitor.endpoints key in values.yaml (silent last-wins override)."
 apiVersion: v2
 appVersion: 5.4.2
 dependencies:
@@ -18,7 +22,7 @@ description: Adminer is a full-featured database management tool written in PHP.
   is available for MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, Firebird, SimpleDB,
   Elasticsearch and MongoDB
 home: https://github.com/startechnica/apps/tree/main/charts/adminer
-icon: https://www.adminer.org/static/images/logo.png
+icon: https://raw.githubusercontent.com/vrana/adminer/master/adminer/static/logo.png
 keywords:
   - adminer
   - postgres
@@ -35,5 +39,6 @@ maintainers:
 name: adminer
 sources:
   - https://www.adminer.org
+  - https://github.com/startechnica/apps.git
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/adminer/README.md
+++ b/charts/adminer/README.md
@@ -2,6 +2,11 @@
 
 # Helm chart for Adminer
 
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/startechnica)](https://artifacthub.io/packages/helm/startechnica/adminer)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: 5.4.2](https://img.shields.io/badge/AppVersion-5.4.2-informational?style=flat-square)
+
 Adminer (formerly phpMinAdmin) is a full-featured database management tool written in PHP. Conversely to phpMyAdmin, it consist of a single file ready to deploy to the target server. Adminer is available for MySQL, PostgreSQL, SQLite, MS SQL, Oracle, Firebird, SimpleDB, Elasticsearch and MongoDB.
 
 [Overview of Adminer](https://www.adminer.org/)

--- a/charts/adminer/templates/Deployment.yaml
+++ b/charts/adminer/templates/Deployment.yaml
@@ -165,8 +165,10 @@ spec:
           {{- else if ne .Values.resourcesPreset "none" }}
           resources: {{- include "st-common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
-          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts }}
           volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath | quote }}
@@ -177,12 +179,12 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- include "st-common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-          {{- end }}
         {{- if .Values.sidecars }}
           {{- include "st-common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.persistence.enabled .Values.extraVolumes }}
       volumes:
+        - name: empty-dir
+          emptyDir: {}
         {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
@@ -191,4 +193,3 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "st-common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-      {{- end }}

--- a/charts/adminer/values-test.yaml
+++ b/charts/adminer/values-test.yaml
@@ -9,9 +9,9 @@ affinity:
         - key: node-role.kubernetes.io/worker
           operator: Exists
 
-config:
-  plugins:
-    - login-ip
+# config:
+#   plugins:
+#     - login-ip
 
 service:
   ipFamilyPolicy: PreferDualStack

--- a/charts/adminer/values.schema.json
+++ b/charts/adminer/values.schema.json
@@ -1,0 +1,1026 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": {
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "compatibility": {
+          "type": "object",
+          "properties": {
+            "openshift": {
+              "type": "object",
+              "properties": {
+                "adaptSecurityContext": {
+                  "type": "string"
+                }
+              }
+            },
+            "omitEmptySeLinuxOptions": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "kubeVersion": {
+      "type": "string"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object",
+      "properties": {}
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "properties": {}
+    },
+    "clusterDomain": {
+      "type": "string"
+    },
+    "extraDeploy": {
+      "type": "array"
+    },
+    "diagnosticMode": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "pullSecrets": {
+          "type": "array"
+        },
+        "debug": {
+          "type": "boolean"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "plugins": {
+          "type": "array"
+        },
+        "design": {
+          "type": "string"
+        },
+        "externalserver": {
+          "type": "string"
+        },
+        "defaultServer": {
+          "type": "string"
+        },
+        "defaultDriver": {
+          "type": "string"
+        },
+        "defaultUsername": {
+          "type": "string"
+        },
+        "defaultPassword": {
+          "type": "string"
+        },
+        "defaultDatabase": {
+          "type": "string"
+        },
+        "autoLogin": {
+          "type": "boolean"
+        },
+        "permanentLogin": {
+          "type": "boolean"
+        },
+        "baseUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "configuration": {
+      "type": "string"
+    },
+    "existingConfigmap": {
+      "type": "string"
+    },
+    "extraStartupArgs": {
+      "type": "string"
+    },
+    "extraFlags": {
+      "type": "string"
+    },
+    "initdbScripts": {
+      "type": "object",
+      "properties": {}
+    },
+    "initdbScriptsConfigMap": {
+      "type": "string"
+    },
+    "extraEnvVars": {
+      "type": "array"
+    },
+    "extraEnvVarsCM": {
+      "type": "string"
+    },
+    "extraEnvVarsSecret": {
+      "type": "string"
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "existingSecretPerPassword": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "horizontalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "targetCPU": {
+          "type": "integer"
+        },
+        "targetMemory": {
+          "type": "integer"
+        },
+        "metrics": {
+          "type": "array"
+        }
+      }
+    },
+    "revisionHistoryLimit": {
+      "type": "integer"
+    },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "schedulerName": {
+      "type": "string"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "string"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "hostAliases": {
+      "type": "array"
+    },
+    "deploymentAnnotations": {
+      "type": "object",
+      "properties": {}
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
+    "podLabels": {
+      "type": "object",
+      "properties": {}
+    },
+    "podAnnotations": {
+      "type": "object",
+      "properties": {}
+    },
+    "podAffinityPreset": {
+      "type": "string"
+    },
+    "podAntiAffinityPreset": {
+      "type": "string"
+    },
+    "nodeAffinityPreset": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array"
+        }
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "properties": {}
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {}
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "topologySpreadConstraints": {
+      "type": "object",
+      "properties": {}
+    },
+    "command": {
+      "type": "array"
+    },
+    "args": {
+      "type": "array"
+    },
+    "lifecycleHooks": {
+      "type": "object",
+      "properties": {}
+    },
+    "containerPorts": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "integer"
+        },
+        "https": {
+          "type": "integer"
+        }
+      }
+    },
+    "extraPorts": {
+      "type": "array"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "fsGroupChangePolicy": {
+          "type": "string"
+        },
+        "sysctls": {
+          "type": "array"
+        },
+        "supplementalGroups": {
+          "type": "array"
+        },
+        "fsGroup": {
+          "type": "integer"
+        }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "privileged": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "runAsGroup": {
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        },
+        "seLinuxOptions": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "resourcesPreset": {
+      "type": "string"
+    },
+    "resources": {
+      "type": "object",
+      "properties": {}
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "successThreshold": {
+          "type": "integer"
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "successThreshold": {
+          "type": "integer"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "successThreshold": {
+          "type": "integer"
+        }
+      }
+    },
+    "customStartupProbe": {
+      "type": "object",
+      "properties": {}
+    },
+    "customLivenessProbe": {
+      "type": "object",
+      "properties": {}
+    },
+    "customReadinessProbe": {
+      "type": "object",
+      "properties": {}
+    },
+    "startupWaitOptions": {
+      "type": "object",
+      "properties": {}
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "sidecars": {
+      "type": "array"
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "size": {
+          "type": "string"
+        },
+        "mountPath": {
+          "type": "string"
+        },
+        "subPath": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "selector": {
+          "type": "object",
+          "properties": {}
+        },
+        "dataSource": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "endpoints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "path": {
+              "type": "string"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            },
+            "honorLabels": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {}
+            },
+            "annotations": {
+              "type": "object",
+              "properties": {}
+            },
+            "selector": {
+              "type": "object",
+              "properties": {}
+            },
+            "relabelings": {
+              "type": "array"
+            },
+            "metricRelabelings": {
+              "type": "array"
+            },
+            "tlsConfig": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "ports": {
+          "type": "object",
+          "properties": {
+            "http": {
+              "type": "integer"
+            },
+            "https": {
+              "type": "integer"
+            }
+          }
+        },
+        "nodePorts": {
+          "type": "object",
+          "properties": {
+            "http": {
+              "type": "string"
+            },
+            "https": {
+              "type": "string"
+            }
+          }
+        },
+        "clusterIP": {
+          "type": "string"
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        },
+        "externalTrafficPolicy": {
+          "type": "string"
+        },
+        "loadBalancerClass": {
+          "type": "string"
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array"
+        },
+        "extraPorts": {
+          "type": "array"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "sessionAffinity": {
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "pathType": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "servicePort": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "tls": {
+          "type": "boolean"
+        },
+        "selfSigned": {
+          "type": "boolean"
+        },
+        "extraHosts": {
+          "type": "array"
+        },
+        "extraPaths": {
+          "type": "array"
+        },
+        "extraTls": {
+          "type": "array"
+        },
+        "secrets": {
+          "type": "array"
+        },
+        "ingressClassName": {
+          "type": "string"
+        },
+        "extraRules": {
+          "type": "array"
+        }
+      }
+    },
+    "tls": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "autoGenerated": {
+          "type": "boolean"
+        },
+        "certificatesMountPath": {
+          "type": "string"
+        },
+        "certificatesSecretName": {
+          "type": "string"
+        },
+        "certFilename": {
+          "type": "string"
+        },
+        "certKeyFilename": {
+          "type": "string"
+        },
+        "certCAFilename": {
+          "type": "string"
+        },
+        "existingSecretName": {
+          "type": "string"
+        },
+        "usePemCerts": {
+          "type": "boolean"
+        },
+        "keyPassword": {
+          "type": "string"
+        },
+        "keystorePassword": {
+          "type": "string"
+        },
+        "passwordsSecret": {
+          "type": "string"
+        },
+        "certManager": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "issuerRef": {
+              "type": "object",
+              "properties": {
+                "group": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "tlsAcme": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "rules": {
+          "type": "array"
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allowExternal": {
+          "type": "boolean"
+        },
+        "allowExternalEgress": {
+          "type": "boolean"
+        },
+        "extraIngress": {
+          "type": "array"
+        },
+        "extraEgress": {
+          "type": "array"
+        },
+        "ingressNSMatchLabels": {
+          "type": "object",
+          "properties": {}
+        },
+        "ingressNSPodMatchLabels": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "implementation": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          }
+        },
+        "clusterDomain": {
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "type": "string"
+        },
+        "selector": {
+          "type": "object",
+          "properties": {}
+        },
+        "gatewayClassName": {
+          "type": "string"
+        },
+        "listeners": {
+          "type": "array"
+        },
+        "existingGateway": {},
+        "hostnames": {
+          "type": "array"
+        },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "selfSigned": {
+              "type": "boolean"
+            },
+            "secrets": {
+              "type": "array"
+            }
+          }
+        },
+        "httpRoute": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "parentRefs": {
+              "type": "array"
+            },
+            "rules": {
+              "type": "object",
+              "properties": {
+                "filters": {
+                  "type": "array"
+                },
+                "matches": {
+                  "type": "array"
+                },
+                "extraBackendRefs": {
+                  "type": "array"
+                }
+              }
+            },
+            "extraRules": {
+              "type": "array"
+            },
+            "existingHTTPRouteName": {
+              "type": "string"
+            }
+          }
+        },
+        "tlsRoute": {
+          "type": "object",
+          "properties": {
+            "parentRefs": {
+              "type": "array"
+            }
+          }
+        },
+        "virtualService": {
+          "type": "object",
+          "properties": {
+            "existingVirtualService": {
+              "type": "string"
+            },
+            "http": {
+              "type": "array"
+            }
+          }
+        },
+        "listenerSet": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "parentRef": {
+              "type": "object",
+              "properties": {}
+            },
+            "listeners": {
+              "type": "array"
+            }
+          }
+        },
+        "referenceGrant": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "from": {
+              "type": "array"
+            },
+            "to": {
+              "type": "array"
+            }
+          }
+        },
+        "mesh": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "waypoint": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string"
+            },
+            "gatewayClassName": {
+              "type": "string"
+            },
+            "extraListeners": {
+              "type": "array"
+            }
+          }
+        },
+        "authorizationPolicy": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "rules": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowAll": {
+                  "type": "boolean"
+                },
+                "denyAll": {
+                  "type": "boolean"
+                },
+                "allow": {
+                  "type": "array"
+                },
+                "deny": {
+                  "type": "array"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "organization": {
+      "type": "string"
+    }
+  }
+}

--- a/charts/adminer/values.yaml
+++ b/charts/adminer/values.yaml
@@ -712,10 +712,6 @@ metrics:
     ## @param metrics.serviceMonitor.tlsConfig TLS configuration for the scrape endpoint (switches scheme to https when set)
     ##
     tlsConfig: {}
-    ## @param metrics.serviceMonitor.endpoints Full endpoint definitions; overrides the single-endpoint shorthand built from `port`/`path`/etc. above.
-    ##
-    endpoints: []
-
 
 ## =============================================================================
 ## @section Traffic Exposure parameters


### PR DESCRIPTION
# Changelog

## 1.0.1 (2026-05-02)

Documentation and validation polish on top of 1.0.0. No template or values
default changes — installs from 1.0.0 upgrade in place with no action.

### Added

- `values.schema.json` — JSON Schema generated from `values.yaml` defaults. Permissive (no `required`, no `additionalProperties: false`); catches gross type mistakes (`replicaCount: "two"`, `service.type: 8080`) at `helm install`/`upgrade` time. Null defaults map to `{}` (any), so existing overrides continue to validate.
- `README.md`: Artifact Hub repository badge plus static `Version` / `Type` / `AppVersion` shields under the title.

### Fixed

- `values.yaml`: duplicate `metrics.serviceMonitor.endpoints` key under `metrics.serviceMonitor`. Helm's YAML loader silently kept the last value (`endpoints: []`) and discarded the shorthand `endpoints: [{path: /metrics}]` that the section above intended. Behavior of the rendered ServiceMonitor is unchanged because `templates/ServiceMonitor.yaml` already falls back to the synthetic single-endpoint when `endpoints` is empty — but stricter YAML loaders (yaml.v3, js-yaml, kubeval pipelines) rejected the file outright.