### PR TITLE
[adminer] Fix ingress annotation rendering

### DIFF
--- a/charts/adminer/templates/Ingress.yaml
+++ b/charts/adminer/templates/Ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
     {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
     {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
-    annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+    {{- include "st-common.tplvalues.render" (dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
## Summary

- fix the Adminer chart ingress annotation render path
- use the chart's `st-common.tplvalues.render` helper
- render merged annotations directly under `metadata.annotations`

Fixes #125.

## Test plan

```sh
helm dependency build charts/adminer
helm lint charts/adminer -f /tmp/adminer-annotations-values.yaml
helm template adminer charts/adminer --skip-tests -f /tmp/adminer-annotations-values.yaml
helm lint charts/adminer -f charts/adminer/values-test.yaml
helm template adminer charts/adminer --skip-tests -f charts/adminer/values-test.yaml
git diff --check
```
