### PR TITLE
[adminer] release 1.0.2 — fix ingress annotations (#125) & pod automountServiceAccountToken (#127), st-common OCI

### DIFF
--- a/charts/adminer/.gitignore
+++ b/charts/adminer/.gitignore
@@ -1,7 +1,6 @@
 *.tgz
 
-# Helm Charts dependencies
+# Helm Charts dependencies (downloaded subcharts). Chart.lock IS committed.
 /charts
-*.lock
 
 .idea

--- a/charts/adminer/CHANGELOG.md
+++ b/charts/adminer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.2 (2026-06-19)
+
+Bug-fix release on top of 1.0.1. Template-only changes — no values defaults or
+appVersion change; installs from 1.0.1 upgrade in place with no action.
+
+### Fixed
+
+- `templates/Ingress.yaml`: ingress annotations failed to render whenever `ingress.annotations` or `commonAnnotations` was set, aborting the template with `no template "common.tplvalues.render" associated with template "gotpl"`. The block called the pre-migration helper name and also emitted a second nested `annotations:` key inside `metadata.annotations`. Now uses `st-common.tplvalues.render` and renders the merged map directly under `metadata.annotations`. ([#125](https://github.com/startechnica/apps/issues/125), reported by [@attilaolah](https://github.com/attilaolah))
+- `templates/Deployment.yaml`: the documented top-level `automountServiceAccountToken` value was never rendered into `spec.template.spec.automountServiceAccountToken`, so token automounting could only be disabled via the chart-created ServiceAccount. Deployments reusing an existing or the namespace `default` ServiceAccount (`serviceAccount.create: false`) had no pod-level override. The pod spec now renders `automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}`. ([#127](https://github.com/startechnica/apps/issues/127), reported by [@attilaolah](https://github.com/attilaolah))
+
+### Changed
+
+- `Chart.yaml`: the `st-common` dependency moved from the GitHub Pages HTTP repo (`https://startechnica.github.io/apps`) to the GHCR OCI registry (`oci://ghcr.io/startechnica/charts`) and bumped 0.1.20 → 0.1.21. Aligns with the `freeradius`/`netbox` charts and removes the Pages-index round-trip. `Chart.lock` is regenerated and committed so ArgoCD's `helm dependency build` resolves the pinned digest.
+
 ## 1.0.1 (2026-05-02)
 
 Documentation and validation polish on top of 1.0.0. No template or values

--- a/charts/adminer/Chart.lock
+++ b/charts/adminer/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: st-common
+  repository: oci://ghcr.io/startechnica/charts
+  version: 0.1.21
+digest: sha256:fbe7d1335c8e14f449988f351cddc4765d4ee3473f0f4eb630a8cfb677a071e2
+generated: "2026-06-19T23:32:51.4898883+07:00"

--- a/charts/adminer/Chart.yaml
+++ b/charts/adminer/Chart.yaml
@@ -4,18 +4,24 @@ annotations:
     - name: adminer
       image: docker.io/adminer:5.4.2-standalone
   artifacthub.io/changes: |
-    - kind: added
-      description: "values.schema.json for runtime validation of values overrides."
-    - kind: added
-      description: "Artifact Hub / Version / Type / AppVersion shields in README."
     - kind: fixed
-      description: "Duplicate metrics.serviceMonitor.endpoints key in values.yaml (silent last-wins override)."
+      description: "Ingress annotations now render (st-common.tplvalues.render helper + dropped stray nested annotations key)."
+      links:
+        - name: GitHub Issue
+          url: https://github.com/startechnica/apps/issues/125
+    - kind: fixed
+      description: "Top-level automountServiceAccountToken now renders on the pod spec, covering serviceAccount.create=false."
+      links:
+        - name: GitHub Issue
+          url: https://github.com/startechnica/apps/issues/127
+    - kind: changed
+      description: "st-common dependency moved from the GitHub Pages HTTP repo to the GHCR OCI registry (oci://ghcr.io/startechnica/charts) and bumped to 0.1.21."
 apiVersion: v2
 appVersion: 5.4.2
 dependencies:
   - name: st-common
-    repository: https://startechnica.github.io/apps
-    version: 0.1.20
+    repository: oci://ghcr.io/startechnica/charts
+    version: 0.1.21
     alias: startechnica-common
 description: Adminer is a full-featured database management tool written in PHP. Conversely
   to phpMyAdmin, it consist of a single file ready to deploy to the target server. Adminer
@@ -41,4 +47,4 @@ sources:
   - https://www.adminer.org
   - https://github.com/startechnica/apps.git
 type: application
-version: 1.0.1
+version: 1.0.2

--- a/charts/adminer/README.md
+++ b/charts/adminer/README.md
@@ -3,7 +3,7 @@
 # Helm chart for Adminer
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/startechnica)](https://artifacthub.io/packages/helm/startechnica/adminer)
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 5.4.2](https://img.shields.io/badge/AppVersion-5.4.2-informational?style=flat-square)
 

--- a/charts/adminer/templates/Deployment.yaml
+++ b/charts/adminer/templates/Deployment.yaml
@@ -42,6 +42,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "st-common.rbac.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- include "st-common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "st-common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/charts/adminer/templates/Ingress.yaml
+++ b/charts/adminer/templates/Ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
     {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
     {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
-    annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+    {{- include "st-common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/charts/adminer/values.yaml
+++ b/charts/adminer/values.yaml
@@ -489,7 +489,7 @@ containerSecurityContext:
 ## choice for the user. This also increases chances charts run on environments with little
 ## resources, such as Minikube. If you do want to specify resources, uncomment the following
 ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, 
+## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium,
 ## large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
 ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
 ##


### PR DESCRIPTION
## Summary

Bug-fix release for the `adminer` chart (1.0.1 → 1.0.2). Template-only behavior changes — no values defaults or `appVersion` change; existing installs upgrade in place with no action.

- **Fixes #125** — ingress annotations failed to render whenever `ingress.annotations` or `commonAnnotations` was set (`no template "common.tplvalues.render" associated with template "gotpl"`). The block called the pre-migration helper name and emitted a second nested `annotations:` key inside `metadata.annotations`. Now uses `st-common.tplvalues.render` and renders the merged map directly under `metadata.annotations`.
- **Fixes #127** — the documented top-level `automountServiceAccountToken` value was never rendered into `spec.template.spec.automountServiceAccountToken`, so it had no effect when `serviceAccount.create: false` (existing/`default` SA reuse). The pod spec now renders it.

Both issues reported by @attilaolah.

## Also in this release

- `st-common` dependency moved from the GitHub Pages HTTP repo to the GHCR OCI registry (`oci://ghcr.io/startechnica/charts`, 0.1.20 → 0.1.21), aligning with `freeradius`/`netbox`. `Chart.lock` regenerated and now committed (chart `.gitignore` no longer ignores `*.lock`).
- Version bump 1.0.2 across `Chart.yaml`, README shield, `artifacthub.io/changes`, and `CHANGELOG.md`.

## Verification

- `helm lint charts/adminer` → 0 failed.
- `helm template` with each issue's reproduction values renders correctly:
  - #125: merged annotations appear once under `metadata.annotations`.
  - #127: `automountServiceAccountToken: false` renders with `serviceAccount.create=false`.
- `helm dependency update` pulled `st-common:0.1.21` from GHCR and pinned the digest.

Closes #125
Closes #127